### PR TITLE
Add GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,58 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+#  schedule:
+#    - cron: '42 5 * * *'
+
+jobs:
+  test-in-container:
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby: [ '2.6', '2.7', '3.0' ]
+
+    runs-on: ubuntu-latest
+    name: OS Ruby ${{matrix.ruby}}
+    container: ruby:${{matrix.ruby}}
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Show Ruby Version
+      run: |
+        ruby -v
+
+    - name: Setup
+      run: |
+        ./bin/setup
+
+    - name: Run tests
+      run: |
+        rake spec
+
+  test-natively:
+    strategy:
+      fail-fast: false
+      matrix:
+        runner: [ubuntu-latest, macos-latest, windows-latest]
+        ruby-version: ['3.0']
+
+    runs-on: ${{matrix.runner}}
+    name: OS ${{matrix.runner}} Ruby ${{matrix.ruby-version}}
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: ${{ matrix.ruby-version }}
+
+    - name: Bundle install
+      run: bundle install
+
+    - name: Run tests
+      run: rake spec
+


### PR DESCRIPTION
Travis-CI has stopped offering its free service.
This PR configure GitHub Actions to run the tests on various versions of Ruby and 3 operating systems.
It currently fails pending #1 

This PR is part of my [Daily CI](https://dev.to/szabgab/the-2022-december-ci-challenge-5dof) project.

